### PR TITLE
Active storage

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,7 +1,7 @@
 class QuestionsController < ApplicationController
 
   # before_action :authenticate_user!, only: [:new, :create, :edit, :destroy, :update]
-  
+
   before_action :set_question, only: [:show, :edit, :destroy, :update]
 
   def index
@@ -17,22 +17,18 @@ class QuestionsController < ApplicationController
 
   def create
     @question = Question.new(question_params)
-    @question['user_id'] = current_user.id
+    @question["user_id"] = current_user.id
     @question.save
   end
 
   def edit
-
   end
-
-  
 
   def show
     
     @comment = Comment.new
     @question = Question.find(params[:id])
     @options = @question.options
-    
   end
 
   def destroy
@@ -43,10 +39,9 @@ class QuestionsController < ApplicationController
   private
 
   def question_params
-    params.require(:question).permit(:question_text, :description, :user_id, :comment_text, :expiry_date, options_attributes:[:option_text])
+    params.require(:question).permit(:question_text, :description, :user_id, :comment_text, :expiry_date, question_images: [], options_attributes: [:option_text])
   end
 
-  
   def set_question
     @question = Question.find(params[:id])
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,4 +5,5 @@ class Question < ApplicationRecord
 
   accepts_nested_attributes_for :options
 
+  has_many_attached :question_images
 end

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -16,6 +16,10 @@
       <%= q.date_field :expiry_date, class: "form-control" %>
     </div>
 
+    <div class="form-row">
+        <%= q.label :question_images, "Images" %>
+        <%= q.file_field :question_images, multiple: true, direct_upload: true %>
+      </div>
     <hr>
 
     <h5> Options </h5>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -45,13 +45,6 @@
 	<%= f.submit 'Vote' %>
 	<% end %>
 
-<<<<<<< HEAD
-=======
-
-
-
-
->>>>>>> 4388a15... added image attachment to questions, multiple images
 	<div class="card">
         <h3>Comments (<%= @question.comments.size %>)</h3>
         <%= render partial: 'questions/comment'%>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -18,8 +18,24 @@
 			<h5 class="card-title"><%= @question.question_text %></h5>
 			<p class="card-text"><%= @question.description %></p>
 			<p class="card-text"><%= @question.expiry_date %></p>
+
+
+			<div class="container">
+				<div class="row">
+					<% if @question.question_images.attached? %>
+					<% @question.question_images.each do |img| %>
+					<div class="col text-center">
+                        <div><%= image_tag img, style: 'height:150px;width:auto;' %></div>
+                        <div><%= img.filename %></div>
+					</div>
+					<% end %>
+					<% end %>
+				</div>
+			</div>
 		</div>
 	</div>
+
+
 
 	<%#= form_with scope: :sitter, url: profile_path, local: true do |form| %>
 
@@ -29,6 +45,13 @@
 	<%= f.submit 'Vote' %>
 	<% end %>
 
+<<<<<<< HEAD
+=======
+
+
+
+
+>>>>>>> 4388a15... added image attachment to questions, multiple images
 	<div class="card">
         <h3>Comments (<%= @question.comments.size %>)</h3>
         <%= render partial: 'questions/comment'%>


### PR DESCRIPTION
- users can now add multiple images when creating a new poll

existing issues
- currently, the image caption is just the image filename eg. "asdgasd.jpg". to add captions to the image, we will need to wrap it in another model. we may have to decide if we want to implement that at some point