### PR TITLE
fix add option bug

### DIFF
--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -70,6 +70,7 @@
             </div>
             <div class="col-1"></div>
         </div>
+    </div>
 
       <button class="btn btn-sm btn-warning mb-2" id="addMore">Add Options</button>
 


### PR DESCRIPTION
- restored a `</div>` in a form that we accidentally deleted during conflict resolution